### PR TITLE
0.2.7 -> 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,9 @@ Currently implemented features are:
  * EZSP application protocol
  * CLI wrapping basic ZigBee network operations (eg, scanning and forming a
    network)
- * Incomplete ZDO functionality (with CLI)
- * Incomplete ZCL functionality (with CLI)
-
-The ZDO and ZCL functionality is currently very brittle -- errors and
-unexpected conditions are not well handled. The application framework is also
-not well set up for applications to build against it. For example, there's
-no way to register for callbacks on network or device events.
+ * ZDO functionality (with CLI)
+ * ZCL functionality (with CLI)
+ * An application framework with device state persistence
 
 An example use of the CLI:
 

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ from setuptools import find_packages, setup
 
 setup(
     name="bellows",
-    version="0.2.7",
-    description="",
+    version="0.3.0",
+    description="Library implementing EZSP and ZigBee",
     url="http://github.com/rcloran/bellows",
     author="Russell Cloran",
     author_email="rcloran@gmail.com",


### PR DESCRIPTION
This is an API-breaking release. Endpoints no longer have a "clusters"
attribute, but a "in_clusters" and "out_clusters" attributes instead.

Highlights:

 - EZSP 5 support (@AndreasBomholtz)
 - More robust handling of RST frames (@AndreasBomholtz)
 - CLI should work on Windows now
 - Python 3.4.2 now works (72bc167a)