### PR TITLE
Make "leave" not remove device; add "remove"

### DIFF
--- a/bellows/cli/application.py
+++ b/bellows/cli/application.py
@@ -181,9 +181,8 @@ def unbind(ctx, endpoint, cluster):
 def leave(ctx):
     """Tell a node to leave the network"""
     app = ctx.obj['app']
-    dev = app.devices[ctx.obj['node']]
 
-    v = yield from dev.zdo.leave()
+    v = yield from app.remove(ctx.obj['node'])
     click.echo(v)
 
 

--- a/bellows/zigbee/appdb.py
+++ b/bellows/zigbee/appdb.py
@@ -40,14 +40,17 @@ class PersistingListener:
     def execute(self, *args, **kwargs):
         return self._cursor.execute(*args, **kwargs)
 
-    def device_left(self, device):
-        self._remove_device(device)
-
     def device_joined(self, device):
         self._save_device(device)
 
     def device_initialized(self, device):
         self._save_device(device)
+
+    def device_left(self, device):
+        pass
+
+    def device_removed(self, device):
+        self._remove_device(device)
 
     def attribute_updated(self, cluster, attrid, value):
         self._save_attribute(

--- a/bellows/zigbee/zdo/types.py
+++ b/bellows/zigbee/zdo/types.py
@@ -121,7 +121,7 @@ CLUSTERS = {
     0x0022: ('Unind_req', (('SrcAddress', t.EmberEUI64), ('SrcEndpoint', t.uint8_t), ('ClusterID', t.uint16_t), ('DstAddress', MultiAddress))),
     # Network Management Server Services Requests
     # ... TODO optional stuff ...
-    0x0034: ('Mgmt_Leave_reg', (('DeviceAddress', t.EmberEUI64), ('Options', t.uint8_t))),  # bitmap8
+    0x0034: ('Mgmt_Leave_req', (('DeviceAddress', t.EmberEUI64), ('Options', t.uint8_t))),  # bitmap8
     0x0036: ('Mgmt_Permit_Joining_req', (('PermitDuration', t.uint8_t), ('TC_Significant', t.Bool))),
     # ... TODO optional stuff ...
 

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from unittest import mock
 
@@ -54,6 +55,18 @@ def test_database(tmpdir, ieee):
     app._handle_leave(99, ieee)
 
     app2 = make_app(db)
+    assert ieee in app2.devices
+
+    @asyncio.coroutine
+    def mockleave(*args, **kwargs):
+        return [0]
+
+    app2.devices[ieee].zdo.leave = mockleave
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(app2.remove(ieee))
     assert ieee not in app2.devices
+
+    app3 = make_app(db)
+    assert ieee not in app3.devices
 
     os.unlink(db)

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -206,6 +206,19 @@ def test_leave_handler(app, ieee):
         'trustCenterJoinHandler',
         [1, ieee, t.EmberDeviceUpdate.DEVICE_LEFT, None, None]
     )
+    assert ieee in app.devices
+
+
+def test_remove(app, ieee):
+    app.devices[ieee] = mock.MagicMock()
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(app.remove(ieee))
+    assert ieee not in app.devices
+
+
+def test_remove_nonexistent(app, ieee):
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(app.remove(ieee))
     assert ieee not in app.devices
 
 


### PR DESCRIPTION
It's normal for a device to leave the network and rejoin. "Leave" shouldn't
remove a device from the application (or the database).