### PR TITLE
Added missing close to leave command

### DIFF
--- a/bellows/cli/network.py
+++ b/bellows/cli/network.py
@@ -118,10 +118,11 @@ def leave(ctx):
     v = yield from util.networkInit(s)
     if v[0] == t.EmberStatus.NOT_JOINED:
         click.echo("Not joined, not leaving")
-        return
+    else:
+        v = yield from s.leaveNetwork()
+        util.check(v[0], "Failure leaving network: %s" % (v[0], ))
 
-    v = yield from s.leaveNetwork()
-    util.check(v[0], "Failure leaving network: %s" % (v[0], ))
+    s.close()
 
 
 @main.command()


### PR DESCRIPTION
This is a fix for the cli leave command.
I got this error when running the command:
```
error: Task was destroyed but it is pending!
error: task: <Task pending coro=<Gateway._send_task() running at /home/andreas/projects/bellows/bellows/uart.py:157> wait_for=<Future pending cb=[Task._wakeup()]>>
Exception ignored in: <generator object Gateway._send_task at 0x7f6d07b93938>
Traceback (most recent call last):
  File "/home/andreas/projects/bellows/bellows/uart.py", line 157, in _send_task
  File "/usr/lib/python3.5/asyncio/queues.py", line 170, in get
  File "/usr/lib/python3.5/asyncio/futures.py", line 227, in cancel
  File "/usr/lib/python3.5/asyncio/futures.py", line 242, in _schedule_callbacks
  File "/usr/lib/python3.5/asyncio/base_events.py", line 497, in call_soon
  File "/usr/lib/python3.5/asyncio/base_events.py", line 506, in _call_soon
  File "/usr/lib/python3.5/asyncio/base_events.py", line 334, in _check_closed
RuntimeError: Event loop is closed
```