### PR TITLE
Change ZDO/ZCL deserialize signature

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -166,7 +166,7 @@ class ControllerApplication(bellows.zigbee.util.ListenableMixin):
         else:
             deserialize = bellows.zigbee.zcl.deserialize
 
-        tsn, command_id, is_reply, args = deserialize(aps_frame, message)
+        tsn, command_id, is_reply, args = deserialize(aps_frame.clusterId, message)
 
         if is_reply:
             self._handle_reply(sender, aps_frame, tsn, command_id, args)

--- a/bellows/zigbee/zcl/__init__.py
+++ b/bellows/zigbee/zcl/__init__.py
@@ -10,7 +10,7 @@ from bellows.zigbee.zcl import foundation
 LOGGER = logging.getLogger(__name__)
 
 
-def deserialize(aps_frame, data):
+def deserialize(cluster_id, data):
     frame_control, data = data[0], data[1:]
     frame_type = frame_control & 0b0011
     direction = (frame_control & 0b1000) >> 3
@@ -23,11 +23,11 @@ def deserialize(aps_frame, data):
 
     if frame_type == 1:
         # Cluster command
-        if aps_frame.clusterId not in Cluster._registry:
+        if cluster_id not in Cluster._registry:
             LOGGER.debug("Ignoring unknown cluster ID 0x%04x",
-                         aps_frame.clusterId)
+                         cluster_id)
             return tsn, command_id + 256, is_reply, data
-        cluster = Cluster._registry[aps_frame.clusterId]
+        cluster = Cluster._registry[cluster_id]
         # Cluster-specific command
 
         if direction:

--- a/bellows/zigbee/zdo/__init__.py
+++ b/bellows/zigbee/zdo/__init__.py
@@ -9,22 +9,22 @@ from . import types
 LOGGER = logging.getLogger(__name__)
 
 
-def deserialize(aps_frame, data):
+def deserialize(cluster_id, data):
     tsn, data = data[0], data[1:]
 
-    is_reply = bool(aps_frame.clusterId & 0x8000)
+    is_reply = bool(cluster_id & 0x8000)
     try:
-        cluster_details = types.CLUSTERS[aps_frame.clusterId]
+        cluster_details = types.CLUSTERS[cluster_id]
     except KeyError:
-        LOGGER.warning("Unknown ZDO cluster 0x%02x", aps_frame.clusterId)
-        return tsn, aps_frame.clusterId, is_reply, data
+        LOGGER.warning("Unknown ZDO cluster 0x%02x", cluster_id)
+        return tsn, cluster_id, is_reply, data
 
     args, data = t.deserialize(data, cluster_details[2])
     if data != b'':
         # TODO: Seems sane to check, but what should we do?
         LOGGER.warning("Data remains after deserializing ZDO frame")
 
-    return tsn, aps_frame.clusterId, is_reply, args
+    return tsn, cluster_id, is_reply, args
 
 
 class ZDO(util.LocalLogMixin, util.ListenableMixin):

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -12,50 +12,44 @@ def aps():
     return t.EmberApsFrame()
 
 
-def test_deserialize_general(aps):
-    aps.clusterId = 0
-    tsn, command_id, is_reply, args = zcl.deserialize(aps, b'\x00\x01\x00')
+def test_deserialize_general():
+    tsn, command_id, is_reply, args = zcl.deserialize(0, b'\x00\x01\x00')
     assert tsn == 1
     assert command_id == 0
     assert is_reply is False
 
 
-def test_deserialize_general_unknown(aps):
-    aps.clusterId = 0
-    tsn, command_id, is_reply, args = zcl.deserialize(aps, b'\x00\x01\xff')
+def test_deserialize_general_unknown():
+    tsn, command_id, is_reply, args = zcl.deserialize(0, b'\x00\x01\xff')
     assert tsn == 1
     assert command_id == 255
     assert is_reply is False
 
 
-def test_deserialize_cluster(aps):
-    aps.clusterId = 0
-    tsn, command_id, is_reply, args = zcl.deserialize(aps, b'\x01\x01\x00xxx')
+def test_deserialize_cluster():
+    tsn, command_id, is_reply, args = zcl.deserialize(0, b'\x01\x01\x00xxx')
     assert tsn == 1
     assert command_id == 256
     assert is_reply is False
 
 
-def test_deserialize_cluster_client(aps):
-    aps.clusterId = 3
-    tsn, command_id, is_reply, args = zcl.deserialize(aps, b'\x09\x01\x00AB')
+def test_deserialize_cluster_client():
+    tsn, command_id, is_reply, args = zcl.deserialize(3, b'\x09\x01\x00AB')
     assert tsn == 1
     assert command_id == 256
     assert is_reply is True
     assert args == [0x4241]
 
 
-def test_deserialize_cluster_unknown(aps):
-    aps.clusterId = 0xff00
-    tsn, command_id, is_reply, args = zcl.deserialize(aps, b'\x05\x00\x00\x01\x00')
+def test_deserialize_cluster_unknown():
+    tsn, command_id, is_reply, args = zcl.deserialize(0xff00, b'\x05\x00\x00\x01\x00')
     assert tsn == 1
     assert command_id == 256
     assert is_reply is False
 
 
-def test_deserialize_cluster_command_unknown(aps):
-    aps.clusterId = 0
-    tsn, command_id, is_reply, args = zcl.deserialize(aps, b'\x01\x01\xff')
+def test_deserialize_cluster_command_unknown():
+    tsn, command_id, is_reply, args = zcl.deserialize(0, b'\x01\x01\xff')
     assert tsn == 1
     assert command_id == 255 + 256
     assert is_reply is False
@@ -91,7 +85,7 @@ def test_request_general(cluster):
     assert cluster._endpoint.device.request.call_count == 1
 
 
-def test_attribute_report(cluster):
+def test_attribute_report(cluster, aps):
     attr = zcl.foundation.Attribute()
     attr.attrid = 4
     attr.value = zcl.foundation.TypeValue()

--- a/tests/test_zdo.py
+++ b/tests/test_zdo.py
@@ -19,18 +19,14 @@ def test_commands():
 
 
 def test_deserialize():
-    frame = t.EmberApsFrame()
-    frame.clusterId = 2
-    tsn, command_id, is_reply, args = zdo.deserialize(frame, b'\x01\x02\x03xx')
+    tsn, command_id, is_reply, args = zdo.deserialize(2, b'\x01\x02\x03xx')
     assert tsn == 1
     assert is_reply is False
     assert args == [0x0302]
 
 
 def test_deserialize_unknown():
-    frame = t.EmberApsFrame()
-    frame.clusterId = 0x0100
-    tsn, command_id, is_reply, args = zdo.deserialize(frame, b'\x01')
+    tsn, command_id, is_reply, args = zdo.deserialize(0x0100, b'\x01')
     assert tsn == 1
     assert is_reply is False
 


### PR DESCRIPTION
The only information needed from the APS frame is the cluster ID. This
moves towards not using any EZSP-specific structures in the zigbee code.