### PR TITLE
Added exception handling to cli connect

### DIFF
--- a/bellows/cli/util.py
+++ b/bellows/cli/util.py
@@ -90,7 +90,11 @@ def setup(dev, cbh=None, configure=True):
     s = bellows.ezsp.EZSP()
     if cbh:
         s.add_callback(cbh)
-    yield from s.connect(dev)
+    try:
+        yield from s.connect(dev)
+    except Exception as e:
+        LOGGER.error(e)
+        raise click.Abort()
     LOGGER.debug("Connected. Resetting.")
     yield from s.reset()
     yield from s.version()


### PR DESCRIPTION
When trying to connect to a device that do not exist, the exception was shown with full backtrace. Now just the error message is shown.