### PR TITLE
Add error reporting when database isn't provided when needed

### DIFF
--- a/bellows/cli/opts.py
+++ b/bellows/cli/opts.py
@@ -38,10 +38,13 @@ baudrate = click.option(
 database_file = click.option(
     '-D', '--database',
     type=click.Path(
+        exists=True,
         dir_okay=False,
         writable=True,
     ),
+    required=True,
     default=os.path.join(click.get_app_dir("bellows"), "app.db"),
+
 )
 
 duration_ms = click.option(

--- a/bellows/cli/opts.py
+++ b/bellows/cli/opts.py
@@ -44,7 +44,6 @@ database_file = click.option(
     ),
     required=True,
     default=os.path.join(click.get_app_dir("bellows"), "app.db"),
-
 )
 
 duration_ms = click.option(


### PR DESCRIPTION
New output:
```
Usage: bellows devices [OPTIONS]

Error: Invalid value for "-D" / "--database": Path "/home/halkeye/.config/bellows/app.db" does not exist.
```