### PR TITLE
Change policy to allow generation of new TC keys

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -305,6 +305,13 @@ class ControllerApplication(bellows.zigbee.util.ListenableMixin):
         if v[0] != 0:
             raise Exception("Failed to set link key")
 
+        v = yield from self._ezsp.setPolicy(
+            t.EzspPolicyId.TC_KEY_REQUEST_POLICY,
+            t.EzspDecisionId.GENERATE_NEW_TC_LINK_KEY,
+        )
+        if v[0] != 0:
+            raise Exception("Failed to change policy to allow generation of new trust center keys")
+
         return self._ezsp.permitJoining(time_s, True)
 
     def get_sequence(self):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -264,7 +264,8 @@ def test_permit(app):
 
 
 def test_permit_with_key(app):
-    app._ezsp.addTransientLinkKey = get_mock_coro([0, 0])
+    app._ezsp.addTransientLinkKey = get_mock_coro([0])
+    app._ezsp.setPolicy = get_mock_coro([0])
 
     loop = asyncio.get_event_loop()
     loop.run_until_complete(app.permit_with_key(bytes([1, 2, 3, 4, 5, 6, 7, 8]), bytes([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x4A, 0xF7]), 60))
@@ -274,7 +275,8 @@ def test_permit_with_key(app):
 
 
 def test_permit_with_key_ieee(app, ieee):
-    app._ezsp.addTransientLinkKey = get_mock_coro([0, 0])
+    app._ezsp.addTransientLinkKey = get_mock_coro([0])
+    app._ezsp.setPolicy = get_mock_coro([0])
 
     loop = asyncio.get_event_loop()
     loop.run_until_complete(app.permit_with_key(ieee, bytes([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x4A, 0xF7]), 60))
@@ -292,6 +294,15 @@ def test_permit_with_key_invalid_install_code(app, ieee):
 
 def test_permit_with_key_failed_add_key(app, ieee):
     app._ezsp.addTransientLinkKey = get_mock_coro([1, 1])
+
+    loop = asyncio.get_event_loop()
+    with pytest.raises(Exception):
+        loop.run_until_complete(app.permit_with_key(ieee, bytes([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x4A, 0xF7]), 60))
+
+
+def test_permit_with_key_failed_set_policy(app, ieee):
+    app._ezsp.addTransientLinkKey = get_mock_coro([0])
+    app._ezsp.setPolicy = get_mock_coro([1])
 
     loop = asyncio.get_event_loop()
     with pytest.raises(Exception):


### PR DESCRIPTION
I was debugging a device and found that this policy has to be set to make the whole join process to finish correctly, when using install key.