### PR TITLE
Handle new id in join

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -233,8 +233,8 @@ class ControllerApplication(bellows.zigbee.util.ListenableMixin):
                 return
         else:
             dev = self.add_device(ieee, nwk)
-            self.listener_event('device_joined', dev)
 
+        self.listener_event('device_joined', dev)
         dev.schedule_initialize()
 
     def _handle_leave(self, nwk, ieee, *args):

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -224,8 +224,10 @@ class ControllerApplication(bellows.zigbee.util.ListenableMixin):
         LOGGER.info("Device 0x%04x (%s) joined the network", nwk, ieee)
         if ieee in self.devices:
             dev = self.get_device(ieee)
-            dev.nwk = nwk
-            if dev.initializing or dev.status == bellows.zigbee.device.Status.ENDPOINTS_INIT:
+            if dev.nwk != nwk:
+                LOGGER.debug("Device %s changed id (0x%04x => 0x%04x)", ieee, dev.nwk, nwk)
+                dev.nwk = nwk
+            elif dev.initializing or dev.status == bellows.zigbee.device.Status.ENDPOINTS_INIT:
                 LOGGER.debug("Skip initialization for existing device %s", ieee)
                 return
         else:

--- a/bellows/zigbee/device.py
+++ b/bellows/zigbee/device.py
@@ -36,9 +36,13 @@ class Device(zutil.LocalLogMixin):
         self.initializing = False
 
     def schedule_initialize(self):
-        self.initializing = True
+        if self.initializing:
+            LOGGER.debug("Canceling old initialize call")
+            self._init_handle.cancel()
+        else:
+            self.initializing = True
         loop = asyncio.get_event_loop()
-        loop.call_soon(asyncio.async, self._initialize())
+        self._init_handle = loop.call_soon(asyncio.async, self._initialize())
 
     @asyncio.coroutine
     def _initialize(self):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -208,6 +208,12 @@ def test_join_handler_skip(app, ieee):
     assert app.devices[ieee].status == device.Status.ZDO_INIT
 
 
+def test_join_handler_change_id(app, ieee):
+    app._handle_join(1, ieee, None, None, None)
+    app._handle_join(2, ieee, None, None, None)
+    assert app.devices[ieee].nwk == 2
+
+
 def test_leave_handler(app, ieee):
     app.devices[ieee] = mock.sentinel.device
     app.ezsp_callback_handler(


### PR DESCRIPTION
If a device changes ID during join we will try to talk to the new ID instead. 
I'm trying to handle the issue #44 