### PR TITLE
Add support for Xiaomi, Trådfri

### DIFF
--- a/bellows/cli/application.py
+++ b/bellows/cli/application.py
@@ -32,6 +32,25 @@ def form(ctx, database, channel, pan_id, extended_pan_id):
 
     return util.app(inner, app_startup=False)(ctx)
 
+@main.command()
+@opts.database_file
+@opts.wshost
+@opts.wsport
+@opts.resthost
+@opts.restport
+@opts.restapikey
+@click.pass_context
+def standalone(ctx, database, wshost, wsport, resthost, restport, rest_api_key):
+    """Run a standalone server."""
+    import bellows.standalone
+    ctx.obj['database_file'] = database
+    ctx.obj['wshost'] = wshost
+    ctx.obj['wsport'] = wsport
+    ctx.obj['resthost'] = resthost
+    ctx.obj['restport'] = restport
+    ctx.obj['rest_api_key'] = rest_api_key
+
+    return util.app(bellows.standalone.start, app_startup=False, run_forever=True)(ctx)
 
 @main.command()
 @opts.database_file

--- a/bellows/cli/application.py
+++ b/bellows/cli/application.py
@@ -8,6 +8,8 @@ import click
 import bellows.ezsp
 import bellows.zigbee.application
 import bellows.zigbee.endpoint
+import bellows.types as t
+from bellows.zigbee.zdo.types import CLUSTER_ID as ZDO_CLUSTER_ID
 from . import opts
 from . import util
 from .main import main
@@ -16,8 +18,8 @@ from .main import main
 @main.command()
 @opts.database_file
 @opts.channel
-@opts.extended_pan
 @opts.pan
+@opts.extended_pan
 @click.pass_context
 def form(ctx, database, channel, pan_id, extended_pan_id):
     """Form a new ZigBee network"""
@@ -136,7 +138,7 @@ def endpoints(ctx):
     if dev is None:
         return
 
-    v = yield from dev.zdo.request(0x0005, dev.nwk)
+    v = yield from dev.zdo.request(ZDO_CLUSTER_ID.Active_EP_req, dev.nwk)
     if v[0] != 0:
         click.echo("Non-success response: %s" % (v, ))
     else:
@@ -213,9 +215,9 @@ def leave(ctx):
 @main.group()
 @click.pass_context
 @opts.database_file
-@click.argument('node', type=util.ZigbeeNodeParamType())
-@click.argument('endpoint', type=click.IntRange(1, 255))
-@click.argument('cluster', type=click.IntRange(0, 65535))
+@opts.arg_node
+@opts.arg_endpoint
+@opts.arg_cluster
 def zcl(ctx, database, node, cluster, endpoint):
     """Peform ZCL operations against a device"""
     ctx.obj['database_file'] = database
@@ -226,7 +228,7 @@ def zcl(ctx, database, node, cluster, endpoint):
 
 @zcl.command()
 @click.pass_context
-@click.argument('attribute', type=click.IntRange(0, 65535))
+@opts.arg_attribute
 @util.app
 def read_attribute(ctx, attribute):
     app = ctx.obj['app']
@@ -251,8 +253,8 @@ def read_attribute(ctx, attribute):
 
 @zcl.command()
 @click.pass_context
-@click.argument('attribute', type=click.IntRange(0, 65535))
-@click.argument('value', type=click.IntRange(0, 65535))
+@opts.arg_attribute
+@opts.arg_attribute_value
 @util.app
 def write_attribute(ctx, attribute, value):
     app = ctx.obj['app']
@@ -311,7 +313,7 @@ def command(ctx, command, parameters):
 
 @zcl.command()
 @click.pass_context
-@click.argument('attribute', type=click.IntRange(0, 65535))
+@opts.arg_attribute
 @click.argument('min_interval', type=click.IntRange(0, 65535))
 @click.argument('max_interval', type=click.IntRange(0, 65535))
 @click.argument('reportable_change', type=click.INT)

--- a/bellows/cli/dump.py
+++ b/bellows/cli/dump.py
@@ -41,7 +41,7 @@ def dump(ctx, channel, outfile):
 
 @asyncio.coroutine
 def _dump(ctx, channel, outfile):
-    s = yield from util.setup(ctx.obj['device'])
+    s = yield from util.setup(ctx.obj['device'], ctx.obj['baudrate'])
     ctx.obj['ezsp'] = s
 
     v = yield from s.mfglibStart(True)

--- a/bellows/cli/dump.py
+++ b/bellows/cli/dump.py
@@ -5,22 +5,13 @@ import click
 import pure_pcapy
 
 from . import util
+from . import opts
 from .main import main
 
 
 @main.command()
-@click.option(
-    '-c', '--channel',
-    type=click.IntRange(11, 26),
-    metavar="CHANNEL",
-    required=True,
-)
-@click.option(
-    '-w', 'outfile',
-    type=click.Path(writable=True, dir_okay=False),
-    metavar="FILE",
-    required=True,
-)
+@opts.channel
+@opts.outfile
 @click.pass_context
 def dump(ctx, channel, outfile):
     """Capture frames on CHANNEL and write to FILE in tcpdump format"""

--- a/bellows/cli/opts.py
+++ b/bellows/cli/opts.py
@@ -69,3 +69,54 @@ pan = click.option(
     '-P', '--pan-id',
     type=click.IntRange(0, 65535),
 )
+
+outfile = click.option(
+    '-w', 'outfile',
+    type=click.Path(writable=True, dir_okay=False),
+    metavar="FILE",
+    required=True,
+)
+
+wshost = click.option(
+    '-ws', '--wshost',
+    type=click.STRING,
+    metavar='<WEBSOCKET HOST>',
+    default='127.0.0.1',
+    show_default=True,
+)
+
+wsport = click.option(
+    '-wp', '--wsport',
+    type=click.IntRange(0, 65535),
+    metavar='<WEBSOCKET PORT>',
+    default=8080,
+    show_default=True,
+)
+
+resthost = click.option(
+    '-rh', '--resthost',
+    type=click.STRING,
+    metavar='<REST HOST>',
+    default='localhost',
+    show_default=True,
+)
+
+restport = click.option(
+    '-rp', '--restport',
+    type=click.IntRange(0, 65535),
+    metavar='<REST PORT>',
+    default=6789,
+    show_default=True,
+)
+
+restapikey = click.option(
+    '-rk', '--rest_api_key',
+    type=click.STRING,
+    metavar='<REST API KEY>',
+)
+
+arg_node = click.argument('node', type=util.ZigbeeNodeParamType())
+arg_endpoint = click.argument('endpoint', type=click.IntRange(1, 255))
+arg_cluster = click.argument('cluster', type=click.IntRange(0, 65535))
+arg_attribute = click.argument('attribute', type=click.IntRange(0, 65535))
+arg_attribute_value = click.argument('value', type=click.IntRange(0, 65535))

--- a/bellows/cli/util.py
+++ b/bellows/cli/util.py
@@ -96,7 +96,7 @@ def channel_mask(channels):
 
 
 @asyncio.coroutine
-def setup(dev, baudrate, cbh=None, configure=True):
+def setup(dev, baudrate=57600, cbh=None, configure=True):
     s = bellows.ezsp.EZSP()
     if cbh:
         s.add_callback(cbh)

--- a/bellows/cli/util.py
+++ b/bellows/cli/util.py
@@ -42,7 +42,7 @@ def async(f):
     return inner
 
 
-def app(f, app_startup=True):
+def app(f, app_startup=True, run_forever=False, shutdown_cb=None):
     database_file = None
 
     @asyncio.coroutine
@@ -70,6 +70,8 @@ def app(f, app_startup=True):
         loop = asyncio.get_event_loop()
         try:
             loop.run_until_complete(async_inner(*args, **kwargs))
+            if run_forever:
+                loop.run_forever()
         except:
             # It seems that often errors like a message send will try to send
             # two messages, and not reading all of them will leave the NCP in
@@ -77,6 +79,8 @@ def app(f, app_startup=True):
             loop.run_until_complete(asyncio.sleep(0.5))
             raise
         finally:
+            if shutdown_cb:
+                shutdown_cb(ctx)
             shutdown()
 
     return inner

--- a/bellows/standalone.py
+++ b/bellows/standalone.py
@@ -1,0 +1,235 @@
+"""Standalone websocket interface to bellows."""
+
+from aiohttp import web
+import asyncio
+import functools
+import json
+import logging
+import websockets
+
+
+log = logging.getLogger(__name__)
+
+
+class RestServer:
+    """REST server."""
+
+    def __init__(self, app, host, port, api_key):
+        """Init."""
+        self.app = app
+        self.host = host
+        self.port = port
+        self.api_key = api_key
+        self.srv = None
+
+        self.mapping = {
+            'GET': {
+                '/api/{api_key}': self._get_index,
+                '/api/{api_key}/lights/{id}': self._get_light,
+                '/api/{api_key}/lights/{id}/reinit': self._reinit_light,
+            },
+
+            'PUT': {
+                '/api/{api_key}/config': self._put_config,
+                '/api/{api_key}/lights/{id}': self._put_light,
+            }
+        }
+
+        self.wapp = web.Application()
+        for method, endpoints in self.mapping.items():
+            for epname, epfun in endpoints.items():
+                self.wapp.router.add_route(method, epname, self._rwrap(epfun))
+
+    def _rwrap(self, handler_func):
+        """Errors are handled and put in json format. """
+        @functools.wraps(handler_func)
+        def wrapper(request):
+            error_code = None
+            try:
+                result = yield from handler_func(request)
+            except web.HTTPClientError as e:
+                log.warning('Http error: %r %r', e.status_code, e.reason,
+                            exc_info=True)
+                error_code = e.status_code
+                result = dict(error_code=error_code,
+                              error_reason=e.reason,
+                              status='FAILED')
+            except Exception as e:
+                log.warning('Server error', exc_info=True)
+                error_code = 500
+                result = dict(error_code=error_code,
+                              error_reason='Unhandled exception',
+                              status='FAILED')
+
+            assert isinstance(result, dict)
+            body = json.dumps(result).encode('utf-8')
+            result = web.Response(body=body)
+            result.headers['Content-Type'] = 'application/json'
+            if error_code:
+                result.set_status(error_code)
+            return result
+
+        return wrapper
+
+    @asyncio.coroutine
+    def _get_index(self, request):
+        log.info('Get config')
+        return dict(answer=42)
+
+    @asyncio.coroutine
+    def _reinit_light(self, request):
+        log.info('Reinit light')
+        print([hex(d.nwk) for d in self.app.devices.values()])
+        try:
+            light_id = int(request.match_info['id'], 16)
+            try:
+                light = self.app.get_device(nwk=light_id)
+            except KeyError:
+                raise web.HTTPNotFound()
+            yield from light.refresh_endpoints()
+        except json.decoder.JSONDecodeError as err:
+            log.info("Invalid json data")
+        finally:
+            pass
+        return dict()
+
+    @asyncio.coroutine
+    def _get_light(self, request):
+        log.info('Get light')
+        return dict(answer=42)
+
+    @asyncio.coroutine
+    def _put_config(self, request):
+        log.info('Put config')
+        try:
+            data = yield from request.json()
+            if "permitjoin" in data:
+                self.app.permit(int(data["permitjoin"]))
+                log.info('Permitting join for %d seconds.', int(data["permitjoin"]))
+        except json.decoder.JSONDecodeError as err:
+            log.info("Invalid json data")
+        finally:
+            pass
+        return dict()
+
+    @asyncio.coroutine
+    def _put_light(self, request):
+        log.info('Put light')
+        try:
+            light_id = int(request.match_info['id'], 16)
+            try:
+                light = self.app.get_device(nwk=light_id)
+            except KeyError:
+                log.info(str([hex(d.nwk) for d in self.app.devices.values()]))
+                raise web.HTTPNotFound()
+            data = yield from request.json()
+            if "on" in data:
+                if data["on"]:
+                    log.info('Turn light on')
+                    yield from light[1].on_off.on()
+                else:
+                    log.info('Turn light off')
+                    yield from light[1].on_off.off()
+        except json.decoder.JSONDecodeError as err:
+            log.info("Invalid json data")
+        finally:
+            pass
+        return dict()
+
+    @asyncio.coroutine
+    def start(self):
+        """Start."""
+        loop = asyncio.get_event_loop()
+        self.srv = yield from loop.create_server(self.wapp.make_handler(),
+                                                 self.host, self.port)
+
+    def shutdown(self):
+        """Shutdown."""
+        self.srv.close()
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self.srv.wait_closed())
+
+
+class WsConnection:
+    """Single websocket connection."""
+
+    def __init__(self, server, socket, path):
+        self.server = server
+        self.socket = socket
+        self.path = path
+
+    @asyncio.coroutine
+    def _handle_message(self, message):
+        """Handle message."""
+        pass
+
+    @asyncio.coroutine
+    def handle(self):
+        """Handle connection."""
+        while True:
+            message = yield from self.socket.recv()
+            yield from self._handle_message(message)
+
+
+class WsServer:
+    """Websocket interface server."""
+
+    def __init__(self, app, host, port):
+        """Init."""
+        self.app = app
+        self.host = host
+        self.port = port
+        self.app.add_listener(self)
+        self.srv = None
+        self.connected = set()
+
+    @asyncio.coroutine
+    def start(self):
+        """Start."""
+        self.srv = yield from websockets.serve(self._handler,
+                                               self.host, self.port)
+
+    @asyncio.coroutine
+    def broadcast(self, *args, **kwargs):
+        """Write to all sockets."""
+        for conn in self.connected:
+            yield from conn.socket.send(*args, **kwargs)
+
+    @asyncio.coroutine
+    def _handler(self, socket, path):
+        """Handle connection."""
+        conn = WsConnection(self, socket, path)
+        self.connected.add(conn)
+        try:
+            yield from conn.handle()
+        finally:
+            self.connected.remove(conn)
+
+    def shutdown(self):
+        """Shutdown."""
+        pass
+
+    def device_initialized(self, device):
+        """Handle device initialized."""
+        self.broadcast("OK")
+
+
+@asyncio.coroutine
+def start(ctx):
+    """Start websocket server."""
+    ctx.obj['wsserver'] = WsServer(ctx.obj['app'],
+                                   ctx.obj['wshost'],
+                                   ctx.obj['wsport'])
+    ctx.obj['restserver'] = RestServer(ctx.obj['app'],
+                                       ctx.obj['resthost'],
+                                       ctx.obj['restport'],
+                                       ctx.obj['rest_api_key'])
+    yield from ctx.obj['wsserver'].start()
+    yield from ctx.obj['restserver'].start()
+    yield from ctx.obj['app'].startup(auto_form=True)
+
+
+def shutdown(ctx):
+    """Shutdown servers."""
+    ctx.obj['restserver'].shutdown()
+    ctx.obj['wsserver'].shutdown()

--- a/bellows/zigbee/appdb.py
+++ b/bellows/zigbee/appdb.py
@@ -119,6 +119,8 @@ class PersistingListener:
         self._db.commit()
 
     def _save_device(self, device):
+        if device.status != bellows.zigbee.device.Status.INITIALIZED:
+            return
         q = "INSERT OR REPLACE INTO devices (ieee, nwk, manufacturer) VALUES (?, ?, ?)"
         self.execute(q, (device.ieee, device.nwk, device.manufacturer_code))
         self._save_endpoints(device)
@@ -135,8 +137,9 @@ class PersistingListener:
         q = "INSERT OR REPLACE INTO endpoints VALUES (?, ?, ?, ?)"
         endpoints = []
         for epid, ep in device.endpoints.items():
-            if epid == 0:
-                continue  # Skip zdo
+            # Skip zdo
+            if epid == 0 or ep.status != bellows.zigbee.endpoint.Status.INITIALIZED:
+                continue
             device_type = getattr(ep, 'device_type', None)
             eprow = (
                 device.ieee,

--- a/bellows/zigbee/appdb.py
+++ b/bellows/zigbee/appdb.py
@@ -31,9 +31,9 @@ class PersistingListener:
 
         self._create_table_devices()
         self._create_table_endpoints()
-        self._create_table_clusters()
+        self._create_table_input_clusters()
         self._create_table_output_clusters()
-        self._create_table_attributes()
+        self._create_table_cluster_attributes()
 
         self._application = application
 
@@ -44,6 +44,9 @@ class PersistingListener:
         self._save_device(device)
 
     def device_initialized(self, device):
+        self._save_device(device)
+
+    def device_updated(self, device):
         self._save_device(device)
 
     def device_left(self, device):
@@ -70,54 +73,54 @@ class PersistingListener:
         ))
 
     def _create_table_devices(self):
-        self._create_table("devices", "(ieee ieee, nwk, status)")
+        self._create_table("devices", "(ieee ieee, nwk INTEGER, manufacturer INTEGER)")
         self._create_index("ieee_idx", "devices", "ieee")
 
     def _create_table_endpoints(self):
         self._create_table(
             "endpoints",
-            "(ieee ieee, endpoint_id, profile_id, device_type device_type, status)",
+            "(ieee ieee, endpoint_id INTEGER, profile_id INTEGER, device_type INTEGER)",
         )
         self._create_index("endpoint_idx", "endpoints", "ieee, endpoint_id")
 
-    def _create_table_clusters(self):
-        self._create_table("clusters", "(ieee ieee, endpoint_id, cluster)")
+    def _create_table_input_clusters(self):
+        self._create_table("input_clusters", "(ieee ieee, endpoint_id INTEGER, cluster INTEGER)")
         self._create_index(
             "cluster_idx",
-            "clusters",
+            "input_clusters",
             "ieee, endpoint_id, cluster",
         )
 
     def _create_table_output_clusters(self):
-        self._create_table("output_clusters", "(ieee ieee, endpoint_id, cluster)")
+        self._create_table("output_clusters", "(ieee ieee, endpoint_id INTEGER, cluster INTEGER)")
         self._create_index(
             "output_cluster_idx",
             "output_clusters",
             "ieee, endpoint_id, cluster",
         )
 
-    def _create_table_attributes(self):
+    def _create_table_cluster_attributes(self):
         self._create_table(
-            "attributes",
-            "(ieee ieee, endpoint_id, cluster, attrid, value)",
+            "cluster_attributes",
+            "(ieee ieee, endpoint_id, cluster INTEGER, attrid INTEGER, value TEXT)",
         )
         self._create_index(
             "attribute_idx",
-            "attributes",
+            "cluster_attributes",
             "ieee, endpoint_id, cluster, attrid"
         )
 
     def _remove_device(self, device):
-        self.execute("DELETE FROM attributes WHERE ieee = ?", (device.ieee, ))
-        self.execute("DELETE FROM clusters WHERE ieee = ?", (device.ieee, ))
+        self.execute("DELETE FROM cluster_attributes WHERE ieee = ?", (device.ieee, ))
+        self.execute("DELETE FROM input_clusters WHERE ieee = ?", (device.ieee, ))
         self.execute("DELETE FROM output_clusters WHERE ieee = ?", (device.ieee, ))
         self.execute("DELETE FROM endpoints WHERE ieee = ?", (device.ieee, ))
         self.execute("DELETE FROM devices WHERE ieee = ?", (device.ieee, ))
         self._db.commit()
 
     def _save_device(self, device):
-        q = "INSERT OR REPLACE INTO devices (ieee, nwk, status) VALUES (?, ?, ?)"
-        self.execute(q, (device.ieee, device.nwk, device.status))
+        q = "INSERT OR REPLACE INTO devices (ieee, nwk, manufacturer) VALUES (?, ?, ?)"
+        self.execute(q, (device.ieee, device.nwk, device.manufacturer_code))
         self._save_endpoints(device)
         for epid, ep in device.endpoints.items():
             if epid == 0:
@@ -128,7 +131,8 @@ class PersistingListener:
         self._db.commit()
 
     def _save_endpoints(self, device):
-        q = "INSERT OR REPLACE INTO endpoints VALUES (?, ?, ?, ?, ?)"
+        self.execute("DELETE FROM endpoints WHERE ieee = ?", (device.ieee, ))
+        q = "INSERT OR REPLACE INTO endpoints VALUES (?, ?, ?, ?)"
         endpoints = []
         for epid, ep in device.endpoints.items():
             if epid == 0:
@@ -139,14 +143,14 @@ class PersistingListener:
                 ep.endpoint_id,
                 getattr(ep, 'profile_id', None),
                 device_type,
-                ep.status,
             )
             endpoints.append(eprow)
         self._cursor.executemany(q, endpoints)
         self._db.commit()
 
     def _save_input_clusters(self, endpoint):
-        q = "INSERT OR REPLACE INTO clusters VALUES (?, ?, ?)"
+        self.execute("DELETE FROM input_clusters WHERE ieee = ?", (endpoint.device.ieee, ))
+        q = "INSERT OR REPLACE INTO input_clusters VALUES (?, ?, ?)"
         clusters = [
             (endpoint.device.ieee, endpoint.endpoint_id, cluster.cluster_id)
             for cluster in endpoint.in_clusters.values()
@@ -155,6 +159,7 @@ class PersistingListener:
         self._db.commit()
 
     def _save_output_clusters(self, endpoint):
+        self.execute("DELETE FROM output_clusters WHERE ieee = ?", (endpoint.device.ieee, ))
         q = "INSERT OR REPLACE INTO output_clusters VALUES (?, ?, ?)"
         clusters = [
             (endpoint.device.ieee, endpoint.endpoint_id, cluster.cluster_id)
@@ -164,7 +169,7 @@ class PersistingListener:
         self._db.commit()
 
     def _save_attribute(self, ieee, endpoint_id, cluster_id, attrid, value):
-        q = "INSERT OR REPLACE INTO attributes VALUES (?, ?, ?, ?, ?)"
+        q = "INSERT OR REPLACE INTO cluster_attributes VALUES (?, ?, ?, ?, ?)"
         self.execute(q, (ieee, endpoint_id, cluster_id, attrid, value))
         self._db.commit()
 
@@ -173,25 +178,22 @@ class PersistingListener:
 
     def load(self):
         LOGGER.debug("Loading application state from %s", self._database_file)
-        for (ieee, nwk, status) in self._scan("devices"):
-            dev = self._application.add_device(ieee, nwk)
-            dev.status = bellows.zigbee.device.Status(status)
+        for (ieee, nwk, manufacturer) in self._scan("devices"):
+            dev = self._application.add_device(ieee, nwk, manufacturer)
+            dev.status = bellows.zigbee.device.Status.INITIALIZED
 
-        for (ieee, epid, profile_id, device_type, status) in self._scan("endpoints"):
+        for (ieee, epid, profile_id, device_type) in self._scan("endpoints"):
             dev = self._application.get_device(ieee)
             ep = dev.add_endpoint(epid)
             ep.profile_id = profile_id
             try:
-                if profile_id == 260:
-                    device_type = bellows.zigbee.profiles.zha.DeviceType(device_type)
-                elif profile_id == 49246:
-                    device_type = bellows.zigbee.profiles.zll.DeviceType(device_type)
+                device_type = bellows.zigbee.profiles.PROFILES[profile_id].DeviceType(device_type)
             except:
                 pass
             ep.device_type = device_type
-            ep.status = bellows.zigbee.endpoint.Status(status)
+            ep.status = bellows.zigbee.endpoint.Status.INITIALIZED
 
-        for (ieee, endpoint_id, cluster) in self._scan("clusters"):
+        for (ieee, endpoint_id, cluster) in self._scan("input_clusters"):
             dev = self._application.get_device(ieee)
             ep = dev.endpoints[endpoint_id]
             ep.add_input_cluster(cluster)
@@ -201,7 +203,7 @@ class PersistingListener:
             ep = dev.endpoints[endpoint_id]
             ep.add_output_cluster(cluster)
 
-        for (ieee, endpoint_id, cluster, attrid, value) in self._scan("attributes"):
+        for (ieee, endpoint_id, cluster, attrid, value) in self._scan("cluster_attributes"):
             dev = self._application.get_device(ieee)
             ep = dev.endpoints[endpoint_id]
             clus = ep.in_clusters[cluster]

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -219,7 +219,7 @@ class ControllerApplication(bellows.zigbee.util.ListenableMixin):
             LOGGER.warning("Message on unknown device 0x%04x", sender)
             return
 
-        return device.handle_message(is_reply, aps_frame, tsn, command_id, args)
+        device.handle_message(is_reply, aps_frame, tsn, command_id, args)
 
     def _handle_join(self, nwk, ieee, device_update, join_dec, parent_nwk):
         LOGGER.info("Device 0x%04x (%s) joined the network", nwk, ieee)

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -137,10 +137,10 @@ class ControllerApplication(bellows.zigbee.util.ListenableMixin):
         )
         assert v[0] == 0  # TODO: Better check
 
-    def add_device(self, ieee, nwk):
+    def add_device(self, ieee, nwk, manufacturer=None):
         assert isinstance(ieee, t.EmberEUI64)
         # TODO: Shut down existing device
-        dev = bellows.zigbee.device.Device(self, ieee, nwk)
+        dev = bellows.zigbee.device.Device(self, ieee, nwk, manufacturer)
         self.devices[ieee] = dev
         return dev
 
@@ -226,7 +226,7 @@ class ControllerApplication(bellows.zigbee.util.ListenableMixin):
         if ieee in self.devices:
             dev = self.get_device(ieee)
             dev.nwk = nwk
-            if dev.initializing or dev.status == bellows.zigbee.device.Status.ENDPOINTS_INIT:
+            if dev.initializing or dev.status == bellows.zigbee.device.Status.INITIALIZED:
                 LOGGER.debug("Skip initialization for existing device %s", ieee)
                 return
         else:

--- a/bellows/zigbee/device.py
+++ b/bellows/zigbee/device.py
@@ -6,6 +6,7 @@ import bellows.types as t
 import bellows.zigbee.endpoint
 import bellows.zigbee.util as zutil
 import bellows.zigbee.zdo as zdo
+from bellows.zigbee.zdo.types import CLUSTER_ID
 
 
 LOGGER = logging.getLogger(__name__)

--- a/bellows/zigbee/specialization.py
+++ b/bellows/zigbee/specialization.py
@@ -1,0 +1,4 @@
+import enum
+
+class VENDOR(enum.IntEnum):
+    IKEA = 0x117c

--- a/bellows/zigbee/util.py
+++ b/bellows/zigbee/util.py
@@ -194,3 +194,10 @@ def convert_install_code(code):
         return None
 
     return aes_mmo_hash(code)
+
+
+class dotdict(dict):
+     """dot.notation access to dictionary attributes"""
+     __getattr__ = dict.get
+     __setattr__ = dict.__setitem__
+     __delattr__ = dict.__delitem__

--- a/bellows/zigbee/zcl/foundation.py
+++ b/bellows/zigbee/zcl/foundation.py
@@ -126,8 +126,25 @@ class TypeValue():
     def deserialize(cls, data):
         self = cls()
         self.type, data = data[0], data[1:]
-        actual_type = DATA_TYPES[self.type][1]
-        self.value, data = actual_type.deserialize(data)
+        if self.type in [0x48, 0x50, 0x51]:  # Array, set or bag
+            etype, data = t.basic.uint8_t.deserialize(data)
+            nofel, data = t.basic.uint16_t.deserialize(data)
+            actual_type = DATA_TYPES[etype][1]
+            self.value = []
+            for i in range(nofel):
+                val, data = actual_type.deserialize(data)
+                self.value.append(val)
+        elif self.type == 0x4c:  # Structure
+            nofel, data = t.basic.uint16_t.deserialize(data)
+            self.value = []
+            for i in range(nofel):
+                etype, data = t.basic.uint8_t.deserialize(data)
+                actual_type = DATA_TYPES[etype][1]
+                val, data = actual_type.deserialize(data)
+                self.value.append(val)
+        else:
+            actual_type = DATA_TYPES[self.type][1]
+            self.value, data = actual_type.deserialize(data)
         return self, data
 
 

--- a/bellows/zigbee/zdo/types.py
+++ b/bellows/zigbee/zdo/types.py
@@ -1,6 +1,7 @@
 import enum
 
 import bellows.types as t
+from bellows.zigbee.util import dotdict
 
 
 class PowerDescriptor(t.EzspStruct):
@@ -91,7 +92,6 @@ NWKI = ('NWKAddrOfInterest', t.uint16_t)
 IEEE = ('IEEEAddr', t.EmberEUI64)
 STATUS = ('Status', t.uint8_t)
 
-
 CLUSTERS = {
     # Device and Service Discovery Server Requests
     0x0000: ('NWK_addr_req', (IEEE, ('RequestType', t.uint8_t), ('StartIndex', t.uint8_t))),
@@ -159,6 +159,8 @@ CLUSTERS = {
     0x8036: ('Mgmt_Permit_Joining_rsp', (STATUS, )),
     # ... TODO optional stuff ...
 }
+
+CLUSTER_ID = dotdict({value[0]: key for key, value in CLUSTERS.items()})
 
 
 # Rewrite to (name, param_names, param_types)

--- a/bellows/zigbee/zdo/types.py
+++ b/bellows/zigbee/zdo/types.py
@@ -118,7 +118,7 @@ CLUSTERS = {
     #  Bind Management Server Services Responses
     0x0020: ('End_Device_Bind_req', (('BindingTarget', t.uint16_t), ('SrcAddress', t.EmberEUI64), ('SrcEndpoint', t.uint8_t), ('ProfileID', t.uint8_t), ('InClusterList', t.LVList(t.uint8_t)), ('OutClusterList', t.LVList(t.uint8_t)))),
     0x0021: ('Bind_req', (('SrcAddress', t.EmberEUI64), ('SrcEndpoint', t.uint8_t), ('ClusterID', t.uint16_t), ('DstAddress', MultiAddress))),
-    0x0022: ('Unind_req', (('SrcAddress', t.EmberEUI64), ('SrcEndpoint', t.uint8_t), ('ClusterID', t.uint16_t), ('DstAddress', MultiAddress))),
+    0x0022: ('Unbind_req', (('SrcAddress', t.EmberEUI64), ('SrcEndpoint', t.uint8_t), ('ClusterID', t.uint16_t), ('DstAddress', MultiAddress))),
     # Network Management Server Services Requests
     # ... TODO optional stuff ...
     0x0034: ('Mgmt_Leave_req', (('DeviceAddress', t.EmberEUI64), ('Options', t.uint8_t))),  # bitmap8

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -203,9 +203,9 @@ def test_join_handler(app, ieee):
 
 def test_join_handler_skip(app, ieee):
     app._handle_join(1, ieee, None, None, None)
-    app.devices[ieee].status = device.Status.ZDO_INIT
+    app.devices[ieee].status = device.Status.INITIALIZED
     app._handle_join(1, ieee, None, None, None)
-    assert app.devices[ieee].status == device.Status.ZDO_INIT
+    assert app.devices[ieee].status == device.Status.INITIALIZED
 
 
 def test_leave_handler(app, ieee):

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -97,7 +97,7 @@ def test_get_aps():
     ieee = t.EmberEUI64(map(t.uint8_t, [0, 1, 2, 3, 4, 5, 6, 7]))
     dev = device.Device(app_mock, ieee, 65535)
     ep = endpoint.Endpoint(dev, 55)
-    ep.status = endpoint.Status.ZDO_INIT
+    ep.status = endpoint.Status.INITIALIZED
     ep.profile_id = 99
     aps = ep.get_aps(255)
     assert aps.profileId == 99

--- a/tests/test_zigbee_util.py
+++ b/tests/test_zigbee_util.py
@@ -152,3 +152,8 @@ def test_fail_convert_install_code():
     message = bytes([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0xFF, 0xFF])
     key = util.convert_install_code(message)
     assert key is None
+
+
+def test_dotdict():
+    dm = util.dotdict({'asdf': 'ert'})
+    assert dm.asdf == 'ert'


### PR DESCRIPTION
I have tried to separate this PR in several commits, however some changes rely on previous commits so I submit it as a single PR for review.

In short I started learning the code a few days ago, and started cleaning as I went - starting to get rid of magic numbers etc, which I am allergic to  =)

I also wanted a way to not use Home Assistant, so I started a base for a standalone mode. The original mode was to mimick the deconz-rest-plugin for ConBee with a websocket for updates and a (Hue compatible) REST interface for control. Not sure where that is going, but it's most definetly useful for debugging, as I can startup bellows as a self-contained server which I can interact with with curl-commands.

In order to deal with Xiaomi sensors (door sensors is what I tested with), I alleviated the demand that all endpoints and clusters must be set up by the time of joining - Xiaomi doesn't report those, but are sent anyway. This is handled by making the message handling asynchronous, and adding missing endpoints/clusters as they present themselves - instead of just warning about it. Xiaomi also uses the Structure zigbee data field, so I added a parser for arrays, structures, set and bags.

In order to support Trådfri devices, I made a minor specialization in the code for IKEA devices, setting profile_id in the aps frame to ZHA even though it's ZLL. For this, I needed to store the manufacturer in the database and since I was already at it I did some cleanup of the database schema - adding device manufacturer and removing device and endpoint status (non-initialized devices/endpoints should not be saved). 

Instead of adding a framework for specialization, I opted to keep it simple and add just the code needed. I think future specializations will reveal how a more generic handling could look, but considering all possible variations is futile at this point.